### PR TITLE
Add an optional id parameter to the ChatMessage object. #14881

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -294,7 +294,9 @@ class ChatMessage(BaseModel):
     role: MessageRole = MessageRole.USER
     additional_kwargs: dict[str, Any] = Field(default_factory=dict)
     blocks: list[ContentBlock] = Field(default_factory=list)
-    id: Optional[str] = Field(default=None, description="Optional unique identifier for the message")
+    id: Optional[str] = Field(
+        default=None, description="Optional unique identifier for the message"
+    )
 
     def __init__(self, /, content: Any | None = None, **data: Any) -> None:
         """

--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -294,6 +294,7 @@ class ChatMessage(BaseModel):
     role: MessageRole = MessageRole.USER
     additional_kwargs: dict[str, Any] = Field(default_factory=dict)
     blocks: list[ContentBlock] = Field(default_factory=list)
+    id: Optional[str] = Field(default=None, description="Optional unique identifier for the message")
 
     def __init__(self, /, content: Any | None = None, **data: Any) -> None:
         """

--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -770,7 +770,9 @@ class Memory(BaseMemory):
         """Get all messages."""
         return await self.sql_store.get_messages(self.session_id, status=status)
 
-    async def aget_by_id(self, message_id: str, status: Optional[MessageStatus] = None) -> Optional[ChatMessage]:
+    async def aget_by_id(
+        self, message_id: str, status: Optional[MessageStatus] = None
+    ) -> Optional[ChatMessage]:
         """
         Get a specific message by its ID.
 
@@ -802,7 +804,9 @@ class Memory(BaseMemory):
         """Get all messages."""
         return asyncio_run(self.aget_all(status=status))
 
-    def get_by_id(self, message_id: str, status: Optional[MessageStatus] = None) -> Optional[ChatMessage]:
+    def get_by_id(
+        self, message_id: str, status: Optional[MessageStatus] = None
+    ) -> Optional[ChatMessage]:
         """
         Get a specific message by its ID.
 

--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -726,6 +726,10 @@ class Memory(BaseMemory):
 
     async def aput(self, message: ChatMessage) -> None:
         """Add a message to the chat store and process waterfall logic if needed."""
+        # Ensure message has an ID if not provided
+        if message.id is None:
+            message.id = str(uuid.uuid4())
+
         # Add the message to the chat store
         await self.sql_store.add_message(
             self.session_id, message, status=MessageStatus.ACTIVE
@@ -736,6 +740,11 @@ class Memory(BaseMemory):
 
     async def aput_messages(self, messages: List[ChatMessage]) -> None:
         """Add a list of messages to the chat store and process waterfall logic if needed."""
+        # Ensure all messages have IDs if not provided
+        for message in messages:
+            if message.id is None:
+                message.id = str(uuid.uuid4())
+
         # Add the messages to the chat store
         await self.sql_store.add_messages(
             self.session_id, messages, status=MessageStatus.ACTIVE
@@ -746,6 +755,11 @@ class Memory(BaseMemory):
 
     async def aset(self, messages: List[ChatMessage]) -> None:
         """Set the chat history."""
+        # Ensure all messages have IDs if not provided
+        for message in messages:
+            if message.id is None:
+                message.id = str(uuid.uuid4())
+
         await self.sql_store.set_messages(
             self.session_id, messages, status=MessageStatus.ACTIVE
         )
@@ -755,6 +769,24 @@ class Memory(BaseMemory):
     ) -> List[ChatMessage]:
         """Get all messages."""
         return await self.sql_store.get_messages(self.session_id, status=status)
+
+    async def aget_by_id(self, message_id: str, status: Optional[MessageStatus] = None) -> Optional[ChatMessage]:
+        """
+        Get a specific message by its ID.
+
+        Args:
+            message_id: The ID of the message to retrieve
+            status: Filter by message status (active, archived, etc.)
+
+        Returns:
+            The message if found, None otherwise
+
+        """
+        all_messages = await self.sql_store.get_messages(self.session_id, status=status)
+        for message in all_messages:
+            if message.id == message_id:
+                return message
+        return None
 
     async def areset(self, status: Optional[MessageStatus] = None) -> None:
         """Reset the memory."""
@@ -769,6 +801,20 @@ class Memory(BaseMemory):
     def get_all(self, status: Optional[MessageStatus] = None) -> List[ChatMessage]:
         """Get all messages."""
         return asyncio_run(self.aget_all(status=status))
+
+    def get_by_id(self, message_id: str, status: Optional[MessageStatus] = None) -> Optional[ChatMessage]:
+        """
+        Get a specific message by its ID.
+
+        Args:
+            message_id: The ID of the message to retrieve
+            status: Filter by message status (active, archived, etc.)
+
+        Returns:
+            The message if found, None otherwise
+
+        """
+        return asyncio_run(self.aget_by_id(message_id, status=status))
 
     def put(self, message: ChatMessage) -> None:
         """Add a message to the chat store and process waterfall logic if needed."""

--- a/llama-index-core/llama_index/core/memory/types.py
+++ b/llama-index-core/llama_index/core/memory/types.py
@@ -45,6 +45,36 @@ class BaseMemory(BaseComponent):
         """Get all chat history."""
         return await asyncio.to_thread(self.get_all)
 
+    def get_by_id(self, message_id: str) -> Optional[ChatMessage]:
+        """
+        Get a specific message by its ID.
+
+        Args:
+            message_id: The ID of the message to retrieve
+
+        Returns:
+            The message if found, None otherwise
+
+        """
+        all_messages = self.get_all()
+        for message in all_messages:
+            if message.id == message_id:
+                return message
+        return None
+
+    async def aget_by_id(self, message_id: str) -> Optional[ChatMessage]:
+        """
+        Get a specific message by its ID (async).
+
+        Args:
+            message_id: The ID of the message to retrieve
+
+        Returns:
+            The message if found, None otherwise
+
+        """
+        return await asyncio.to_thread(self.get_by_id, message_id)
+
     @abstractmethod
     def put(self, message: ChatMessage) -> None:
         """Put chat history."""

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -120,6 +120,7 @@ def test_chat_message_serializer():
         content="test content",
         additional_kwargs={"some_list": ["a", "b", "c"], "some_object": SimpleModel()},
     )
+    temp_str = str(m.model_dump())
     assert m.model_dump() == {
         "role": MessageRole.USER,
         "additional_kwargs": {
@@ -127,6 +128,7 @@ def test_chat_message_serializer():
             "some_object": {"some_field": ""},
         },
         "blocks": [{"block_type": "text", "text": "test content"}],
+        "id": None,
     }
 
 
@@ -141,6 +143,7 @@ def test_chat_message_legacy_roundtrip():
         "additional_kwargs": {},
         "blocks": [{"block_type": "text", "text": "foo"}],
         "role": MessageRole.USER,
+        "id": None,
     }
 
 

--- a/llama-index-core/tests/memory/test_message_id.py
+++ b/llama-index-core/tests/memory/test_message_id.py
@@ -1,0 +1,75 @@
+"""Test message ID functionality in memory components."""
+
+import pytest
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.memory.memory import Memory
+
+
+def test_chat_message_id():
+    """Test that ChatMessage can have an ID set."""
+    # Create message with ID
+    message_with_id = ChatMessage(content="Test message", role=MessageRole.USER, id="test-id-123")
+    assert message_with_id.id == "test-id-123"
+
+    # Create message without ID
+    message_without_id = ChatMessage(content="Test message", role=MessageRole.USER)
+    assert message_without_id.id is None
+
+
+@pytest.mark.asyncio
+async def test_memory_message_id():
+    """Test that Memory handles message IDs properly."""
+    memory = Memory.from_defaults()
+
+    # Add message with ID
+    message1 = ChatMessage(content="Message 1", role=MessageRole.USER, id="msg-1")
+    await memory.aput(message1)
+
+    # Add message without ID (should get auto-assigned)
+    message2 = ChatMessage(content="Message 2", role=MessageRole.ASSISTANT)
+    await memory.aput(message2)
+
+    # Verify message2 got an ID
+    messages = await memory.aget_all()
+    assert len(messages) == 2
+    assert messages[0].id == "msg-1"
+    assert messages[1].id is not None
+    assert messages[1].content == "Message 2"
+
+    # Get message by ID
+    retrieved_message = await memory.aget_by_id("msg-1")
+    assert retrieved_message is not None
+    assert retrieved_message.content == "Message 1"
+
+    # Try getting message with non-existent ID
+    non_existent = await memory.aget_by_id("non-existent-id")
+    assert non_existent is None
+
+
+@pytest.mark.asyncio
+async def test_memory_multiple_messages():
+    """Test that Memory.aput_messages assigns IDs to multiple messages."""
+    memory = Memory.from_defaults()
+
+    # Create messages
+    messages = [
+        ChatMessage(content="Message 1", role=MessageRole.USER, id="msg-1"),
+        ChatMessage(content="Message 2", role=MessageRole.ASSISTANT),  # No ID
+        ChatMessage(content="Message 3", role=MessageRole.USER)  # No ID
+    ]
+
+    # Add messages
+    await memory.aput_messages(messages)
+
+    # Verify messages
+    retrieved = await memory.aget_all()
+    assert len(retrieved) == 3
+    assert retrieved[0].id == "msg-1"
+    assert retrieved[1].id is not None  # Auto-assigned
+    assert retrieved[2].id is not None  # Auto-assigned
+
+    # Get message by ID
+    msg1 = await memory.aget_by_id("msg-1")
+    assert msg1 is not None
+    assert msg1.content == "Message 1"

--- a/llama-index-core/tests/memory/test_message_id.py
+++ b/llama-index-core/tests/memory/test_message_id.py
@@ -9,7 +9,9 @@ from llama_index.core.memory.memory import Memory
 def test_chat_message_id():
     """Test that ChatMessage can have an ID set."""
     # Create message with ID
-    message_with_id = ChatMessage(content="Test message", role=MessageRole.USER, id="test-id-123")
+    message_with_id = ChatMessage(
+        content="Test message", role=MessageRole.USER, id="test-id-123"
+    )
     assert message_with_id.id == "test-id-123"
 
     # Create message without ID
@@ -56,7 +58,7 @@ async def test_memory_multiple_messages():
     messages = [
         ChatMessage(content="Message 1", role=MessageRole.USER, id="msg-1"),
         ChatMessage(content="Message 2", role=MessageRole.ASSISTANT),  # No ID
-        ChatMessage(content="Message 3", role=MessageRole.USER)  # No ID
+        ChatMessage(content="Message 3", role=MessageRole.USER),  # No ID
     ]
 
     # Add messages


### PR DESCRIPTION
# Description

Adding optional id params to ChatMessage, with linear #get_by_id for now 

Fixes # 14881
https://github.com/run-llama/llama_index/issues/14881


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
